### PR TITLE
Add week of action events to the site

### DIFF
--- a/components/event.js
+++ b/components/event.js
@@ -7,8 +7,13 @@ const Event = (props) => {
 
       <div className = "text-body"><p>{props.event.time}</p><p>{props.event.location}</p></div>
 
-      <div className = "col-span-2"><p className ="font-bold text-subheader-mobile  mt-6 tablet:mt-0 tablet:text-subheader ">{props.event.title}</p>
-      <p className = "mt-2 text-body ">{props.event.description}</p></div>
+      <div className = "col-span-2">
+        <a  href={props.event.href}
+            className ="font-bold text-subheader-mobile  cursor-pointer mt-6 tablet:mt-0 tablet:text-subheader ">
+        {props.event.title}
+        </a>
+      <p className = "mt-2 text-body ">{props.event.description}</p>
+      </div>
     </li>
   </div>);
 }

--- a/data/displayData.js
+++ b/data/displayData.js
@@ -1,26 +1,90 @@
 
 export const Events = [
   {
-    day: "11 Mar 2021",
-    time: "10:00 AM - 12:00 AM",
+    day: "Tuesday, April 13, 2021",
+    time: "5:30 PM -  6:30 PM",
     location: "Online",
-    title: "Organizer Commitee Q3 Budget Meeting",
-    description: " Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer faucibus velit nec porttitor facilisis. Aliquam pharetra nunc placerat elementum porta. Sed mattis in lectus at dapibus. Morbi eu hendrerit odio, quis imperdiet mi. Nulla nec augue ac dui tincidunt mollis in a neque. Aenean sed pretium lacus. Nulla venenatis nibh vitae scelerisque condimentum. Sed dapibus feugiat magna, id elementum neque tristique ut. "
+    href: "https://actionnetwork.org/events/housing-healthcare-what-the-ny-health-act-could-mean-for-housing-justice",
+    title: "Housing & Healthcare: What the NY Health Act Could Mean for Housing Justice",
+    description: "The New York Health Act has been reintroduced with a majority of cosponsors in the New York State Senate and Assembly for the first time! This means that we're closer than ever to winning single-payer healthcare for all New Yorkers, and the effects of universal health coverage would have effects far beyond the field of healthcare. Join us on Tuesday, April 13th for a conversation with tenants' rights advocates and legislators about what the New York Health Act could mean housing justice in New York!"
   },
+    
   {
-    day: "12 Mar 2021",
-    time: "10:00 AM - 12:00 AM",
-    location: "Online",
-    title: "Something else!",
-    description: " Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer faucibus velit nec porttitor facilisis. Aliquam pharetra nunc placerat elementum porta. Sed mattis in lectus at dapibus. Morbi eu hendrerit odio, quis imperdiet mi. Nulla nec augue ac dui tincidunt mollis in a neque. Aenean sed pretium lacus. Nulla venenatis nibh vitae scelerisque condimentum. Sed dapibus feugiat magna, id elementum neque tristique ut. "
+    day: "",
+    time: "",
+    location: "",
+    href: "",
+    title: "",
+    description: ""
   },
+
   {
-    day: "13 Mar 2021",
-    time: "10:00 AM - 12:00 AM",
+    day: "Wednesday, April 14, 2021",
+    time: "6:00 PM - 7:00 PM",
     location: "Online",
-    title: "Townhall",
-    description: " Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer faucibus velit nec porttitor facilisis. Aliquam pharetra nunc placerat elementum porta. Sed mattis in lectus at dapibus. Morbi eu hendrerit odio, quis imperdiet mi. Nulla nec augue ac dui tincidunt mollis in a neque. Aenean sed pretium lacus. Nulla venenatis nibh vitae scelerisque condimentum. Sed dapibus feugiat magna, id elementum neque tristique ut. "
-  }
+    href: "https://actionnetwork.org/events/passnyhealth-to-promote-racial-justice-panel-and-qa",
+    title: "#PassNYHealth to Promote Racial Justice: Teach-in/Panel",
+    description: "As part of the NYHA Week of Action, join the NYC-DSA Healthcare Working Group and the NYC-DSA Racial Justice Working Group for a panel and Q&A that explores topics at the intersection of health justice and racial justice. We'll be talking about how the New York Health Act can be a tool for racial justice, about the places where healthcare and the #DefundNYPD campaign intersect, and how we can focus on anti-racism in our health justice organizing. "
+  },
+
+  {
+    day: "Thursday, April 15, 2021",
+    time: "6:00 PM - 7:30 PM",
+    location: "Online",
+    href: "https://actionnetwork.org/events/labor-for-new-york-health-phonebank",
+    title: "Labor for New York Health Phonebank",
+    description: "Join DSA union members for a crucial phonebank to help win additional cosponsors of the New York Health Act."
+  },
+
+  {
+    day: "Thursday, April 15, 2021",
+    time: "8:00 PM - 9:00 PM",
+    location: "Online",
+    href: "https://actionnetwork.org/events/statewide-labor-strategy-meeting-to-passnyhealth",
+    title: "Statewide Labor Strategy Meeting to #PassNYHealth ",
+    description:
+        "NYC DSA has been eliciting statements of support for the New York Health Act from union locals, caucuses and inter-union formations. We'd like to expand this project beyond New York City and get similar statements from union locals in the rest of the state. This is a rare moment in time where such statements can really affect a crucial  outcome - getting the NYHA out of committee, voted on, and passed." +
+        "Please join activists from around NY State for a statewide strategy meeting to keep up the pressure and build out our movement to DSA chapters across New York."
+  },
+
+  {
+    day: "Friday, April 16, 2021",
+    time: "7:00 PM -  8:30 PM",
+    location: "Online",
+    href: "https://actionnetwork.org/events/passnyhealth-why-now-and-heres-how",
+    title: "#PassNYHealth: Why Now and Here's How",
+    description: "Come hear about the history of the movement for universal healthcare in the United States and how we can learn from it to #PassNYHealth!"
+  },
+/*
+  {
+    day: "",
+    time: "",
+    location: "",
+    href: "",
+    title: "",
+    description: ""
+  },
+*/
+  {
+    day: "Saturday, April 17, 2021",
+    time: "1:00 PM - 5:00 PM",
+    location: "Grand Army Plaza, 10 Grand Army Plaza, Brooklyn, NY 11238",
+    href: "https://actionnetwork.org/events/canvass-and-party-for-the-new-york-health-act",
+    title: "Canvass and Party for the New York Health Act!",
+    description: "Join us Saturday, April 17 for a street canvass at Grand Army Plaza and a post-canvass picnic/party in Prospect Park! We'll gather at 1 p.m. at Grand Army to talk to our neighbors about the New York Health Act and ask them to call key legislators and get involved in our campaign. There will be a training at the start of the event for all new canvassers!\n" +
+        "\n" +
+        "Then, at 3, we'll meet up near the Picnic House in Prospect Park for a socially-distant picnic/party, where we can share food and drinks and socialize! "
+  },
+
+  {
+    day: "Sunday, April 18, 2021",
+    time: "1:00 PM - 2:30 PM",
+    location: "Online",
+    href: "https://actionnetwork.org/events/passnyhealth-new-york-health-act-town-hall-featuring-julia-salazar",
+    title: "#PassNYHealth: New York Health Act Town Hall featuring Julia Salazar",
+    description: "Join the New York City Democratic Socialists of America’s Healthcare Working Group for a town hall on our campaign to #PassNYHealth!"
+  },
+
 ];
 
 export const NavLinks = [

--- a/pages/about.js
+++ b/pages/about.js
@@ -49,10 +49,6 @@ export default function About() {
         <NavMenu />
         <SplashScreen />
         <AboutInfo description={renderInformation.aboutPage.description}/>
-        <AboutDSA />
-        <OurValues ourValues={renderInformation.aboutPage.ourValues}/>
-        <OurHistory />
-        <Signup />
         <DonateLink />
       </main>
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -23,7 +23,6 @@ export default function Home() {
         <NavMenu />
         <SplashScreen />
         <UpComingEvents />
-        <Signup />
         <DonateLink />
       </main>
 


### PR DESCRIPTION
This change adds the current week of action to the static site. This
is managed by a JSON file and not action network. In order to have
something by the end of the week I have taken a short cut and just
hard coded the events to the site. This should make it more usable.